### PR TITLE
Fix missing app_location input

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-coast-0848b7a03.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-coast-0848b7a03.yml
@@ -41,8 +41,8 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "dist/play-app/browser" # Built app content directory
-          api_location: "" # Api source code path - optional
-          output_location: "" # Not needed when app_location points to built files
+          api_location: "api" # Api source code path - optional
+          output_location: "dist/play-app/browser" # Built app content directory
           skip_app_build: true # We already built the app above
           ###### End of Repository/Build Configurations ######
 


### PR DESCRIPTION
Populate `api_location` and `output_location` in Azure Static Web Apps workflow to fix 'Missing required input `app_location`' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe20f6eb-ca38-4464-b182-c8f0a0426d71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe20f6eb-ca38-4464-b182-c8f0a0426d71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>